### PR TITLE
Fix: Resolve CORS error by specifying allowed origins

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -52,6 +52,9 @@ class Settings(BaseSettings):
             port=self.DATABASE_PORT,
             path=self.DATABASE_NAME,
         )
-    all_cors_origins: list[str] = ["*"]
+    all_cors_origins: list[str] = [
+        "http://localhost:5173",
+        "http://127.0.0.1:5173"
+    ]
 
 settings = Settings()# type: ignore[call-arg] | because we load the args from the env


### PR DESCRIPTION
Fix: Resolve CORS error by specifying allowed origins
Description

This PR fixes a high-severity bug where the browser blocks all frontend requests to the backend due to a CORS policy violation. The error No 'Access-Control-Allow-Origin' header is present on the requested resource was appearing in the browser console, preventing any interaction between the frontend running on http://localhost:5173 and the backend.

The root cause was the use of a wildcard ("*") for allow_origins in the CORS middleware configuration while also having allow_credentials=True. This combination is disallowed by the CORS specification for security reasons.

The Fix

The fix replaces the wildcard origin with an explicit list of trusted frontend origins.

In app/core/config.py, the all_cors_origins setting has been updated from ["*"] to ["http://localhost:5173", "http://127.0.0.1:5173"].

This change ensures that the backend now sends the correct Access-Control-Allow-Origin header in response to preflight requests from the frontend, resolving the issue.

How to Test:

1) Pull this branch.

2) Ensure the backend is running.

3) Run the frontend application from http://localhost:5173.

4) Open the browser's developer tools and navigate to the Network tab.

5) call http://backend.docker.localhost/products/{id}

6) Verify that the OPTIONS preflight request returns a 200 OK status and that the subsequent GET/POST request succeeds without any CORS errors.

Closes: #3 